### PR TITLE
Parsed cancellation token down (from the control to MediatR and EFCore)

### DIFF
--- a/CwkSocial/CwkSocial.Api/Controllers/V1/IdentityController.cs
+++ b/CwkSocial/CwkSocial.Api/Controllers/V1/IdentityController.cs
@@ -17,10 +17,10 @@ public class IdentityController : BaseController
     [HttpPost]
     [Route(ApiRoutes.Identity.Registration)]
     [ValidateModel]
-    public async Task<IActionResult> Register(UserRegistration registration)
+    public async Task<IActionResult> Register(UserRegistration registration, CancellationToken cancellationToken)
     {
         var command = _mapper.Map<RegisterIdentity>(registration);
-        var result = await _mediator.Send(command);
+        var result = await _mediator.Send(command, cancellationToken);
 
         if (result.IsError) return HandleErrorResponse(result.Errors);
 
@@ -32,10 +32,10 @@ public class IdentityController : BaseController
     [HttpPost]
     [Route(ApiRoutes.Identity.Login)]
     [ValidateModel]
-    public async Task<IActionResult> Login(Login login)
+    public async Task<IActionResult> Login(Login login, CancellationToken cancellationToken)
     {
         var command = _mapper.Map<LoginCommand>(login);
-        var result = await _mediator.Send(command);
+        var result = await _mediator.Send(command, cancellationToken);
 
         if (result.IsError) return HandleErrorResponse(result.Errors);
 

--- a/CwkSocial/CwkSocial.Api/Controllers/V1/PostsController.cs
+++ b/CwkSocial/CwkSocial.Api/Controllers/V1/PostsController.cs
@@ -16,9 +16,9 @@
         }
 
         [HttpGet]
-        public async Task<IActionResult> GetAllPosts()
+        public async Task<IActionResult> GetAllPosts(CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(new GetAllPosts());
+            var result = await _mediator.Send(new GetAllPosts(), cancellationToken);
             var mapped = _mapper.Map<List<PostResponse>>(result.Payload);
             return result.IsError ? HandleErrorResponse(result.Errors) :  Ok(mapped); 
             
@@ -27,11 +27,11 @@
         [HttpGet]
         [Route(ApiRoutes.Posts.IdRoute)]
         [ValidateGuid("id")]
-        public async Task<IActionResult> GetById(string id)
+        public async Task<IActionResult> GetById(string id, CancellationToken cancellationToken)
         {
             var postId = Guid.Parse(id);
             var query = new GetPostById() {PostId = postId};
-            var result = await _mediator.Send(query);
+            var result = await _mediator.Send(query, cancellationToken);
             var mapped = _mapper.Map<PostResponse>(result.Payload);
 
             return result.IsError ? HandleErrorResponse(result.Errors) : Ok(mapped);
@@ -39,7 +39,7 @@
 
         [HttpPost]
         [ValidateModel]
-        public async Task<IActionResult> CreatePost([FromBody] PostCreate newPost)
+        public async Task<IActionResult> CreatePost([FromBody] PostCreate newPost, CancellationToken cancellationToken)
         {
             var userProfileId = HttpContext.GetUserProfileIdClaimValue();
             
@@ -49,7 +49,7 @@
                 TextContent = newPost.TextContent
             };
 
-            var result = await _mediator.Send(command);
+            var result = await _mediator.Send(command, cancellationToken);
             var mapped = _mapper.Map<PostResponse>(result.Payload);
             
             return result.IsError ? HandleErrorResponse(result.Errors) 
@@ -60,7 +60,7 @@
         [Route(ApiRoutes.Posts.IdRoute)]
         [ValidateGuid("id")]
         [ValidateModel]
-        public async Task<IActionResult> UpdatePostText([FromBody] PostUpdate updatedPost, string id)
+        public async Task<IActionResult> UpdatePostText([FromBody] PostUpdate updatedPost, string id, CancellationToken cancellationToken)
         {
             var userProfileId = HttpContext.GetUserProfileIdClaimValue();
             
@@ -70,7 +70,7 @@
                 PostId = Guid.Parse(id),
                 UserProfileId = userProfileId
             };
-            var result = await _mediator.Send(command);
+            var result = await _mediator.Send(command, cancellationToken);
 
             return result.IsError ? HandleErrorResponse(result.Errors) : NoContent();
         }
@@ -78,11 +78,11 @@
         [HttpDelete]
         [Route(ApiRoutes.Posts.IdRoute)]
         [ValidateGuid("id")]
-        public async Task<IActionResult> DeletePost(string id)
+        public async Task<IActionResult> DeletePost(string id, CancellationToken cancellationToken)
         {
             var userProfileId = HttpContext.GetUserProfileIdClaimValue();
             var command = new DeletePost() {PostId = Guid.Parse(id), UserProfileId = userProfileId};
-            var result = await _mediator.Send(command);
+            var result = await _mediator.Send(command, cancellationToken);
 
             return result.IsError ? HandleErrorResponse(result.Errors) : NoContent();
         }
@@ -90,10 +90,10 @@
         [HttpGet]
         [Route(ApiRoutes.Posts.PostComments)]
         [ValidateGuid("postId")]
-        public async Task<IActionResult> GetCommentsByPostId(string postId)
+        public async Task<IActionResult> GetCommentsByPostId(string postId, CancellationToken cancellationToken)
         {
             var query = new GetPostComments() {PostId = Guid.Parse(postId)};
-            var result = await _mediator.Send(query);
+            var result = await _mediator.Send(query, cancellationToken);
 
             if (result.IsError)  HandleErrorResponse(result.Errors);
 
@@ -105,7 +105,7 @@
         [Route(ApiRoutes.Posts.PostComments)]
         [ValidateGuid("postId")]
         [ValidateModel]
-        public async Task<IActionResult> AddCommentToPost(string postId, [FromBody] PostCommentCreate comment)
+        public async Task<IActionResult> AddCommentToPost(string postId, [FromBody] PostCommentCreate comment, CancellationToken cancellationToken)
         {
             var isValidGuid = Guid.TryParse(comment.UserProfileId, out var userProfileId);
             if (!isValidGuid)
@@ -127,7 +127,7 @@
                 CommentText = comment.Text
             };
 
-            var result = await _mediator.Send(command);
+            var result = await _mediator.Send(command, cancellationToken);
 
             if (result.IsError) return HandleErrorResponse(result.Errors);
 

--- a/CwkSocial/CwkSocial.Api/Controllers/V1/UserProfilesController.cs
+++ b/CwkSocial/CwkSocial.Api/Controllers/V1/UserProfilesController.cs
@@ -18,10 +18,10 @@ namespace CwkSocial.Api.Controllers.V1
         }
 
         [HttpGet]
-        public async Task<IActionResult> GetAllProfiles()
+        public async Task<IActionResult> GetAllProfiles(CancellationToken cancellationToken)
         {
             var query = new GetAllUserProfiles();
-            var response = await _mediator.Send(query);
+            var response = await _mediator.Send(query, cancellationToken);
             var profiles = _mapper.Map<List<UserProfileResponse>>(response.Payload);
             return Ok(profiles);
         }
@@ -29,10 +29,10 @@ namespace CwkSocial.Api.Controllers.V1
         [Route(ApiRoutes.UserProfiles.IdRoute)]
         [HttpGet]
         [ValidateGuid("id")]
-        public async Task<IActionResult> GetUserProfileById(string id)
+        public async Task<IActionResult> GetUserProfileById(string id, CancellationToken cancellationToken)
         {
             var query = new GetUserProfileById { UserProfileId = Guid.Parse(id)};
-            var response = await _mediator.Send(query);
+            var response = await _mediator.Send(query, cancellationToken);
 
             if (response.IsError)
                 return HandleErrorResponse(response.Errors);
@@ -45,11 +45,11 @@ namespace CwkSocial.Api.Controllers.V1
         [Route(ApiRoutes.UserProfiles.IdRoute)]
         [ValidateModel]
         [ValidateGuid("id")]
-        public async Task<IActionResult> UpdateUserProfile(string id, UserProfileCreateUpdate updatedProfile)
+        public async Task<IActionResult> UpdateUserProfile(string id, UserProfileCreateUpdate updatedProfile, CancellationToken cancellationToken)
         {
             var command = _mapper.Map<UpdateUserProfileBasicInfo>(updatedProfile);
             command.UserProfileId = Guid.Parse(id);
-            var response = await _mediator.Send(command);
+            var response = await _mediator.Send(command, cancellationToken);
 
             return response.IsError ? HandleErrorResponse(response.Errors) : NoContent();
         }
@@ -60,10 +60,10 @@ namespace CwkSocial.Api.Controllers.V1
         [HttpDelete]
         [Route(ApiRoutes.UserProfiles.IdRoute)]
         [ValidateGuid("id")]
-        public async Task<IActionResult> DeleteUserProfile(string id)
+        public async Task<IActionResult> DeleteUserProfile(string id, CancellationToken cancellationToken)
         {
             var command = new DeleteUserProfile() { UserProfileId = Guid.Parse(id)};
-            var response = await _mediator.Send(command);
+            var response = await _mediator.Send(command, cancellationToken);
 
             return response.IsError ? HandleErrorResponse(response.Errors) : NoContent();
         }

--- a/CwkSocial/CwkSocial.Api/Controllers/V2/PostsController.cs
+++ b/CwkSocial/CwkSocial.Api/Controllers/V2/PostsController.cs
@@ -9,7 +9,7 @@
 
         [HttpGet]
         [Route("{id}")]
-        public IActionResult GetById(int id)
+        public IActionResult GetById(int id, CancellationToken cancellationToken)
         {
             return Ok();
         }

--- a/CwkSocial/CwkSocial.Application/Identity/Handlers/LoginCommandHandler.cs
+++ b/CwkSocial/CwkSocial.Application/Identity/Handlers/LoginCommandHandler.cs
@@ -34,7 +34,7 @@ public class LoginCommandHandler : IRequestHandler<LoginCommand, OperationResult
             if (identityUser == null) return result;
 
             var userProfile = await _ctx.UserProfiles
-                .FirstOrDefaultAsync(up => up.IdentityId == identityUser.Id);
+                .FirstOrDefaultAsync(up => up.IdentityId == identityUser.Id, cancellationToken: cancellationToken);
 
             result.Payload = GetJwtString(identityUser, userProfile);
             return result;

--- a/CwkSocial/CwkSocial.Application/Posts/CommandHandlers/AddPostCommentHandler.cs
+++ b/CwkSocial/CwkSocial.Application/Posts/CommandHandlers/AddPostCommentHandler.cs
@@ -23,7 +23,7 @@ public class AddPostCommentHandler : IRequestHandler<AddPostComment, OperationRe
 
         try
         {
-            var post = await _ctx.Posts.FirstOrDefaultAsync(p => p.PostId == request.PostId);
+            var post = await _ctx.Posts.FirstOrDefaultAsync(p => p.PostId == request.PostId, cancellationToken: cancellationToken);
             if (post is null)
             {
                 result.IsError = true;
@@ -41,7 +41,7 @@ public class AddPostCommentHandler : IRequestHandler<AddPostComment, OperationRe
             post.AddPostComment(comment);
 
             _ctx.Posts.Update(post);
-            await _ctx.SaveChangesAsync();
+            await _ctx.SaveChangesAsync(cancellationToken);
 
             result.Payload = comment;
 

--- a/CwkSocial/CwkSocial.Application/Posts/CommandHandlers/CreatePostHandler.cs
+++ b/CwkSocial/CwkSocial.Application/Posts/CommandHandlers/CreatePostHandler.cs
@@ -24,7 +24,7 @@ public class CreatePostHandler : IRequestHandler<CreatePost, OperationResult<Pos
         {
             var post = Post.CreatePost(request.UserProfileId, request.TextContent);
             _ctx.Posts.Add(post);
-            await _ctx.SaveChangesAsync();
+            await _ctx.SaveChangesAsync(cancellationToken);
 
             result.Payload = post;
         }

--- a/CwkSocial/CwkSocial.Application/Posts/CommandHandlers/DeletePostHandler.cs
+++ b/CwkSocial/CwkSocial.Application/Posts/CommandHandlers/DeletePostHandler.cs
@@ -22,7 +22,7 @@ public class DeletePostHandler : IRequestHandler<DeletePost, OperationResult<Pos
         var result = new OperationResult<Post>();
         try
         {
-            var post = await _ctx.Posts.FirstOrDefaultAsync(p => p.PostId == request.PostId);
+            var post = await _ctx.Posts.FirstOrDefaultAsync(p => p.PostId == request.PostId, cancellationToken: cancellationToken);
             
             if (post is null)
             {
@@ -43,7 +43,7 @@ public class DeletePostHandler : IRequestHandler<DeletePost, OperationResult<Pos
             }
 
             _ctx.Posts.Remove(post);
-            await _ctx.SaveChangesAsync();
+            await _ctx.SaveChangesAsync(cancellationToken);
 
             result.Payload = post;
         }

--- a/CwkSocial/CwkSocial.Application/Posts/CommandHandlers/UpdatePostTextHandler.cs
+++ b/CwkSocial/CwkSocial.Application/Posts/CommandHandlers/UpdatePostTextHandler.cs
@@ -24,7 +24,7 @@ public class UpdatePostTextHandler : IRequestHandler<UpdatePostText, OperationRe
 
         try
         {
-            var post = await _ctx.Posts.FirstOrDefaultAsync(p => p.PostId == request.PostId);
+            var post = await _ctx.Posts.FirstOrDefaultAsync(p => p.PostId == request.PostId, cancellationToken: cancellationToken);
             
             if (post is null)
             {
@@ -46,7 +46,7 @@ public class UpdatePostTextHandler : IRequestHandler<UpdatePostText, OperationRe
             
             post.UpdatePostText(request.NewText);
 
-            await _ctx.SaveChangesAsync();
+            await _ctx.SaveChangesAsync(cancellationToken);
 
             result.Payload = post;
         }

--- a/CwkSocial/CwkSocial.Application/UserProfiles/CommandHandlers/DeleteUserProfileHandler.cs
+++ b/CwkSocial/CwkSocial.Application/UserProfiles/CommandHandlers/DeleteUserProfileHandler.cs
@@ -25,7 +25,7 @@ namespace CwkSocial.Application.UserProfiles.CommandHandlers
         {
             var result = new OperationResult<UserProfile>();
             var userProfile = await _ctx.UserProfiles
-                .FirstOrDefaultAsync(up => up.UserProfileId == request.UserProfileId);
+                .FirstOrDefaultAsync(up => up.UserProfileId == request.UserProfileId, cancellationToken: cancellationToken);
             
             if (userProfile is null)
             {
@@ -37,7 +37,7 @@ namespace CwkSocial.Application.UserProfiles.CommandHandlers
             }
 
             _ctx.UserProfiles.Remove(userProfile);
-            await _ctx.SaveChangesAsync();
+            await _ctx.SaveChangesAsync(cancellationToken);
 
             result.Payload = userProfile;
             return result;

--- a/CwkSocial/CwkSocial.Application/UserProfiles/CommandHandlers/UpdateUserProfileBasicInfoHandler.cs
+++ b/CwkSocial/CwkSocial.Application/UserProfiles/CommandHandlers/UpdateUserProfileBasicInfoHandler.cs
@@ -30,7 +30,7 @@ namespace CwkSocial.Application.UserProfiles.CommandHandlers
             try
             {
                 var userProfile = await _ctx.UserProfiles
-                    .FirstOrDefaultAsync(up => up.UserProfileId == request.UserProfileId);
+                    .FirstOrDefaultAsync(up => up.UserProfileId == request.UserProfileId, cancellationToken: cancellationToken);
 
                 if (userProfile is null)
                 {
@@ -47,7 +47,7 @@ namespace CwkSocial.Application.UserProfiles.CommandHandlers
                 userProfile.UpdateBasicInfo(basicInfo);
 
                 _ctx.UserProfiles.Update(userProfile);
-                await _ctx.SaveChangesAsync();
+                await _ctx.SaveChangesAsync(cancellationToken);
                 
                 result.Payload = userProfile;
                 return result;

--- a/CwkSocial/CwkSocial.Application/UserProfiles/QueryHandlers/GetAllUserProfilesQueryHandler.cs
+++ b/CwkSocial/CwkSocial.Application/UserProfiles/QueryHandlers/GetAllUserProfilesQueryHandler.cs
@@ -25,7 +25,7 @@ namespace CwkSocial.Application.UserProfiles.QueryHandlers
             CancellationToken cancellationToken)
         {
             var result = new OperationResult<IEnumerable<UserProfile>>();
-            result.Payload =  await _ctx.UserProfiles.ToListAsync();
+            result.Payload =  await _ctx.UserProfiles.ToListAsync(cancellationToken: cancellationToken);
             return result;
         }
     }

--- a/CwkSocial/CwkSocial.Application/UserProfiles/QueryHandlers/GetUserProfileByIdHandler.cs
+++ b/CwkSocial/CwkSocial.Application/UserProfiles/QueryHandlers/GetUserProfileByIdHandler.cs
@@ -28,7 +28,7 @@ namespace CwkSocial.Application.UserProfiles.QueryHandlers
             var result = new OperationResult<UserProfile>();
             
             var profile = await _ctx.UserProfiles
-                .FirstOrDefaultAsync(up => up.UserProfileId == request.UserProfileId);
+                .FirstOrDefaultAsync(up => up.UserProfileId == request.UserProfileId, cancellationToken: cancellationToken);
             
             if (profile is null)
             {


### PR DESCRIPTION
By parsing down the cancellation token we be able to cancel a request while calling the database.
That saves a lot of resources on the server.
Issue #9 